### PR TITLE
format not a string literal and no format arguments

### DIFF
--- a/src/grid.c
+++ b/src/grid.c
@@ -45,7 +45,7 @@ void grid_fill(grid *g)
 }
 
 void grid_print_buffer(grid *g, char* tag) {
-    printf(tag);
+    printf("%s", tag);
     for (int i = 0; i < g->buffer_size; i++)
     {
         printf("0x%02x%s", g->buffer[i], i == g->buffer_size - 1 ? "\n" : ",");


### PR DESCRIPTION
Need this to compile with `-Wall -Werror` on my installed gcc.